### PR TITLE
breaking: Reworking the widget model API and simplifying registration of custom widgets

### DIFF
--- a/lib/src/misc/index.dart
+++ b/lib/src/misc/index.dart
@@ -1,5 +1,4 @@
 export 'script_runner.dart';
 export 'logger/index.dart';
 export 'parser.dart';
-export 'resource_loader.dart';
 export "annotations.dart";

--- a/lib/src/misc/resource_loader.dart
+++ b/lib/src/misc/resource_loader.dart
@@ -1,5 +1,0 @@
-abstract interface class ResourceLoader<T> {
-  const ResourceLoader();
-
-  Future<T> load();
-}

--- a/lib/src/registry_api/factory_record.dart
+++ b/lib/src/registry_api/factory_record.dart
@@ -1,7 +1,0 @@
-import 'package:duit_kernel/duit_kernel.dart';
-
-/// The [FactoryRecord] is a [Record] of factory functions that can be used to build custom components
-typedef FactoryRecord = ({
-  ModelFactory modelFactory,
-  BuildFactory buildFactory,
-});

--- a/lib/src/registry_api/registry.dart
+++ b/lib/src/registry_api/registry.dart
@@ -2,12 +2,11 @@ import 'dart:async';
 
 import 'package:duit_kernel/duit_kernel.dart';
 import 'package:duit_kernel/src/registry_api/components/index.dart';
-import 'package:duit_kernel/src/registry_api/factory_record.dart';
 
 /// The [DuitRegistry] class is responsible for registering and retrieving
 /// model factories, build factories, and attributes factories for custom DUIT elements.
 sealed class DuitRegistry {
-  static final Map<String, FactoryRecord> _customComponentRegistry = {};
+  static final Map<String, BuildFactory> _customComponentRegistry = {};
   static DebugLogger _logger = DefaultLogger.instance;
   static ComponentRegistry _componentRegistry = DefaultComponentRegistry();
   static DuitTheme _theme = const DuitTheme({});
@@ -88,39 +87,35 @@ sealed class DuitRegistry {
   /// - The [attributesFactory] is a function that maps the attributes from json to [DuitAttributes.
   static void register(
     String key, {
-    required ModelFactory modelFactory,
     required BuildFactory buildFactory,
   }) {
-    _customComponentRegistry[key] = (
-      modelFactory: modelFactory,
-      buildFactory: buildFactory,
-    );
+    _customComponentRegistry[key] = buildFactory;
 
     _logger.info(
       "Custom widget $key registered successfull",
     );
   }
 
-  /// Returns the model factory registered with the specified [tag].
-  ///
-  /// Returns `null` if the specified [tag] is not registered.
-  static ModelFactory? getModelFactory(String tag) {
-    final factory = _customComponentRegistry[tag]?.modelFactory;
-    if (factory != null) {
-      return factory;
-    } else {
-      _logger.warn(
-        "Not found model factory for specified tag - $tag",
-      );
-      return null;
-    }
-  }
+  // /// Returns the model factory registered with the specified [tag].
+  // ///
+  // /// Returns `null` if the specified [tag] is not registered.
+  // static ModelFactory? getModelFactory(String tag) {
+  //   final factory = _customComponentRegistry[tag]?.modelFactory;
+  //   if (factory != null) {
+  //     return factory;
+  //   } else {
+  //     _logger.warn(
+  //       "Not found model factory for specified tag - $tag",
+  //     );
+  //     return null;
+  //   }
+  // }
 
   /// Returns the build factory registered with the specified [tag].
   ///
   /// Returns `null` if the specified [tag] is not registered.
   static BuildFactory? getBuildFactory(String tag) {
-    final factory = _customComponentRegistry[tag]?.buildFactory;
+    final factory = _customComponentRegistry[tag];
     if (factory != null) {
       return factory;
     } else {

--- a/lib/src/registry_api/registry.dart
+++ b/lib/src/registry_api/registry.dart
@@ -96,20 +96,6 @@ sealed class DuitRegistry {
     );
   }
 
-  // /// Returns the model factory registered with the specified [tag].
-  // ///
-  // /// Returns `null` if the specified [tag] is not registered.
-  // static ModelFactory? getModelFactory(String tag) {
-  //   final factory = _customComponentRegistry[tag]?.modelFactory;
-  //   if (factory != null) {
-  //     return factory;
-  //   } else {
-  //     _logger.warn(
-  //       "Not found model factory for specified tag - $tag",
-  //     );
-  //     return null;
-  //   }
-  // }
 
   /// Returns the build factory registered with the specified [tag].
   ///

--- a/lib/src/registry_api/registry.dart
+++ b/lib/src/registry_api/registry.dart
@@ -76,15 +76,7 @@ sealed class DuitRegistry {
     }
   }
 
-  /// Registers a DUIT element with the specified key, model mapper, renderer, and attributes mapper.
-  ///
-  /// - The [key] is a unique identifier for the DUIT element.
-  ///
-  /// - The [modelFactory] is a function that maps the DUIT element to a [ElementTreeEntry].
-  ///
-  /// - The [buildFactory] is a function that returns the [Widget] representation of the [ElementTreeEntry].
-  ///
-  /// - The [attributesFactory] is a function that maps the attributes from json to [DuitAttributes.
+  /// Registers a build factory for a custom Duit element.
   static void register(
     String key, {
     required BuildFactory buildFactory,
@@ -95,7 +87,6 @@ sealed class DuitRegistry {
       "Custom widget $key registered successfull",
     );
   }
-
 
   /// Returns the build factory registered with the specified [tag].
   ///

--- a/lib/src/ui/tree_element.dart
+++ b/lib/src/ui/tree_element.dart
@@ -22,27 +22,13 @@ import 'package:flutter/widgets.dart';
 /// Methods:
 /// - [renderView]: Abstract method that must be implemented to render the element as a widget.
 abstract base class ElementTreeEntry {
-  /// The type of the DUIT element.
-  final String type, id;
-  final bool controlled;
-  final String? tag;
-  abstract UIElementController? viewController;
-  abstract ViewAttribute? attributes;
+  UIElementController get viewController;
 
-  ElementTreeEntry({
-    required this.type,
-    required this.id,
-    required this.controlled,
-    this.tag,
-  });
+  ViewAttribute get attributes;
+
+  List<ElementTreeEntry> get children;
+
+  ElementTreeEntry? get child;
 
   Widget renderView();
-
-  // set viewController(UIElementController viewController) {
-  //   this.viewController = viewController;
-  // }
-
-  // set attributes(ViewAttribute attributes) {
-  //   this.attributes = attributes;
-  // }
 }

--- a/lib/src/view_attributes/data_source.dart
+++ b/lib/src/view_attributes/data_source.dart
@@ -3745,10 +3745,12 @@ extension type DuitDataSource(Map<String, dynamic> json)
   }) {
     final value = json[key];
 
-    if (value is List<Map<String, dynamic>>) {
+    if (value is List) {
       final list = <DuitTweenDescription>[];
 
       for (final tweenDescription in value) {
+        if (tweenDescription is! Map<String, dynamic>) continue;
+
         final tweenData = DuitDataSource(tweenDescription);
         final tweenType = tweenData.tweenType();
 

--- a/lib/src/view_attributes/data_source.dart
+++ b/lib/src/view_attributes/data_source.dart
@@ -3745,7 +3745,7 @@ extension type DuitDataSource(Map<String, dynamic> json)
   }) {
     final value = json[key];
 
-    if (value is List<Map<String, dynamic>>) {
+    if (value is List) {
       final list = <DuitTweenDescription>[];
 
       for (final tweenDescription in value) {

--- a/lib/src/view_attributes/data_source.dart
+++ b/lib/src/view_attributes/data_source.dart
@@ -3745,7 +3745,7 @@ extension type DuitDataSource(Map<String, dynamic> json)
   }) {
     final value = json[key];
 
-    if (value is List) {
+    if (value is List<Map<String, dynamic>>) {
       final list = <DuitTweenDescription>[];
 
       for (final tweenDescription in value) {


### PR DESCRIPTION
- Removed unused factory_record.dart file and updated component registration logic in DuitRegistry class,
- Removed references to model factories. 
- Updated factory getter methods to match new changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified component registration by requiring only a build factory when registering custom components.
  * Streamlined the element tree structure by replacing fields with abstract getters and adding new getters for child elements.

* **Chores**
  * Removed unused type definitions, interfaces, and related code to reduce complexity.
  * Removed export of resource loader module.

* **Bug Fixes**
  * Broadened input type handling in data source attributes to accept any list type for tween animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->